### PR TITLE
Fix rendering of paraglider in fight mode

### DIFF
--- a/src/main/java/net/cravencraft/epicparagliders/EpicParaglidersMod.java
+++ b/src/main/java/net/cravencraft/epicparagliders/EpicParaglidersMod.java
@@ -1,6 +1,7 @@
 package net.cravencraft.epicparagliders;
 
 import net.cravencraft.epicparagliders.capabilities.UpdatedPlayerMovement;
+import net.cravencraft.epicparagliders.events.FixParagliderRender;
 import net.cravencraft.epicparagliders.network.ModNet;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.capabilities.RegisterCapabilitiesEvent;
@@ -29,6 +30,7 @@ public class EpicParaglidersMod
 
         // Register ourselves for server and other game events we are interested in
         MinecraftForge.EVENT_BUS.register(this);
+        MinecraftForge.EVENT_BUS.register(new FixParagliderRender());
     }
 
     @SubscribeEvent

--- a/src/main/java/net/cravencraft/epicparagliders/events/FixParagliderRender.java
+++ b/src/main/java/net/cravencraft/epicparagliders/events/FixParagliderRender.java
@@ -1,0 +1,56 @@
+package net.cravencraft.epicparagliders.events;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.model.EntityModel;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.client.event.RenderHandEvent;
+import net.minecraftforge.client.event.RenderLivingEvent;
+import net.minecraftforge.eventbus.api.EventPriority;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import tictim.paraglider.item.ParagliderItem;
+
+public class FixParagliderRender {
+    // DawnCraft-Tweaks
+    private boolean isParagliding(LivingEntity entity) {
+        ItemStack item = entity.getMainHandItem();
+
+        if (item.isEmpty()) {
+            return false;
+        }
+
+        return ParagliderItem.isItemParagliding(item);
+    }
+
+
+    @SubscribeEvent(priority = EventPriority.HIGHEST)
+    public void renderLivingEventStart(RenderLivingEvent.Pre<? extends LivingEntity, ? extends EntityModel<? extends LivingEntity>> event) {
+        if (isParagliding(event.getEntity())) {
+            event.setCanceled(true);
+        }
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOWEST, receiveCanceled = true)
+    public void renderLivingEventEnd(RenderLivingEvent.Pre<? extends LivingEntity, ? extends EntityModel<? extends LivingEntity>> event) {
+        if (isParagliding(event.getEntity())) {
+            event.setCanceled(false);
+        }
+    }
+
+
+    @SubscribeEvent(priority = EventPriority.HIGHEST)
+    public void renderHandEventStart(RenderHandEvent event) {
+        Minecraft mc = Minecraft.getInstance();
+        if (isParagliding(mc.player)) {
+            event.setCanceled(true);
+        }
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOWEST, receiveCanceled = true)
+    public void renderHandEventEnd(RenderHandEvent event) {
+        Minecraft mc = Minecraft.getInstance();
+        if (isParagliding(mc.player)) {
+            event.setCanceled(false);
+        }
+    }
+}


### PR DESCRIPTION
This should fix the rendering of the paraglider when epic fight animations are active. It's currently targeting the main branch, but you can probably apply the same commit to the release 1.18.2 branch.

There is one issue, you can still do attacks if you are gliding, which looks kind of broken, but I'm pretty sure that fixing it would require a mixin.

The code is mostly just taken from DawnCraft-Tweaks source, they also have a MIT license though, and it's not even attributed to any person.

[LICENSE](https://github.com/SmileycorpMC/DawnCraft-Tweaks/blob/master/LICENSE)